### PR TITLE
feature/S12P11A502-103:기록장 기능 구현

### DIFF
--- a/module-api/build.gradle.kts
+++ b/module-api/build.gradle.kts
@@ -4,4 +4,5 @@ dependencies {
     implementation("org.springframework.boot:spring-boot-starter-validation")
     implementation("org.springframework.boot:spring-boot-starter-oauth2-resource-server")
     implementation("org.springdoc:springdoc-openapi-starter-webmvc-ui:2.8.3")
+    implementation("org.springframework.boot:spring-boot-starter-data-elasticsearch")
 }

--- a/module-api/src/main/java/live/dolang/api/note/controller/UserNoteController.java
+++ b/module-api/src/main/java/live/dolang/api/note/controller/UserNoteController.java
@@ -1,0 +1,41 @@
+package live.dolang.api.note.controller;
+
+import live.dolang.api.note.document.UserNoteDocument;
+import live.dolang.api.note.dto.UserNoteRequestDto;
+import live.dolang.api.note.service.UserNoteService;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.*;
+
+import java.util.List;
+
+@RestController
+@RequestMapping("/notes")
+@RequiredArgsConstructor
+public class UserNoteController {
+
+    private final UserNoteService userNoteService;
+
+    // 문장 또는 단어 추가 (MySQL & Elasticsearch 저장)
+    @PostMapping
+    public ResponseEntity<Boolean> createUserNote(@RequestBody UserNoteRequestDto requestDto) {
+        boolean success = userNoteService.saveUserNote(requestDto);
+        if (success) {
+            return ResponseEntity.ok(true); // 저장 성공
+        } else {
+            return ResponseEntity.status(500).body(false); // 저장 실패
+        }
+    }
+
+    // 기록 조회 (Elasticsearch에서 ID로 조회, 실패 시 MySQL)
+    @GetMapping("/{userId}")
+    public ResponseEntity<List<UserNoteDocument>> getUserNotes(@PathVariable Integer userId) {
+        return ResponseEntity.ok(userNoteService.getUserNoteById(userId));
+    }
+
+    // 기록 검색 (Elasticsearch에서 키워드 검색)
+    @GetMapping("/{userId}/search")
+    public ResponseEntity<List<UserNoteDocument>> searchNotes(@PathVariable Integer userId, @RequestParam String keyword) {
+        return ResponseEntity.ok(userNoteService.searchUserNotes(userId, keyword));
+    }
+}

--- a/module-api/src/main/java/live/dolang/api/note/controller/UserNoteController.java
+++ b/module-api/src/main/java/live/dolang/api/note/controller/UserNoteController.java
@@ -10,7 +10,7 @@ import org.springframework.web.bind.annotation.*;
 import java.util.List;
 
 @RestController
-@RequestMapping("/notes")
+@RequestMapping("/api/note")
 @RequiredArgsConstructor
 public class UserNoteController {
 

--- a/module-api/src/main/java/live/dolang/api/note/document/UserNoteDocument.java
+++ b/module-api/src/main/java/live/dolang/api/note/document/UserNoteDocument.java
@@ -1,0 +1,38 @@
+package live.dolang.api.note.document;
+
+import lombok.*;
+import org.springframework.data.annotation.Id;
+import org.springframework.data.elasticsearch.annotations.*;
+
+import java.time.Instant;
+
+@Setter
+@Getter
+@Builder
+@NoArgsConstructor
+@AllArgsConstructor
+@Document(indexName = "user_notes")  // ES의 인덱스 이름
+public class UserNoteDocument {
+
+    @Id
+    private String id;  // Elasticsearch에서 사용할 문서 ID
+
+    @Field(type = FieldType.Integer, name = "user_id")
+    private Integer userId;  // 특정 유저의 데이터만 필터링하기 위한 필드
+
+    @Field(type = FieldType.Text, analyzer = "standard", name = "native_note")
+    private String nativeNote;  // 사용자가 입력한 모국어 문장
+
+    @Field(type = FieldType.Text, analyzer = "standard", name = "interest_note")
+    private String interestNote;  // 사용자가 관심 있는 언어의 문장
+
+    @Field(type = FieldType.Keyword, name = "native_language_id")
+    private String nativeLanguageId;  // 모국어 언어 코드 (ex: "en", "ko")
+
+    @Field(type = FieldType.Keyword, name = "interest_language_id")
+    private String interestLanguageId;  // 관심 언어 코드 (ex: "fr", "es")
+
+    @Field(type = FieldType.Date, name = "created_at")
+    private Instant createdAt;  // 생성 날짜 (ES에서 날짜 필드로 저장)
+
+}

--- a/module-api/src/main/java/live/dolang/api/note/dto/UserNoteRequestDto.java
+++ b/module-api/src/main/java/live/dolang/api/note/dto/UserNoteRequestDto.java
@@ -1,0 +1,18 @@
+package live.dolang.api.note.dto;
+
+import lombok.Getter;
+import lombok.Setter;
+
+@Getter
+@Setter
+public class UserNoteRequestDto {
+
+    public UserNoteRequestDto() {
+    }
+
+    private Integer userId;
+    private String nativeNote;
+    private String interestNote;
+    private String nativeLanguageId;
+    private String interestLanguageId;
+}

--- a/module-api/src/main/java/live/dolang/api/note/repository/UserNoteSearchRepository.java
+++ b/module-api/src/main/java/live/dolang/api/note/repository/UserNoteSearchRepository.java
@@ -1,0 +1,37 @@
+package live.dolang.api.note.repository;
+
+import live.dolang.api.note.document.UserNoteDocument;
+import org.springframework.data.elasticsearch.annotations.Query;
+import org.springframework.data.elasticsearch.repository.ElasticsearchRepository;
+import org.springframework.stereotype.Repository;
+
+import java.util.List;
+
+@Repository
+public interface UserNoteSearchRepository extends ElasticsearchRepository<UserNoteDocument, String> {
+
+    // 특정 유저의 모든 기록 조회
+    List<UserNoteDocument> findByUserId(Integer userId);
+
+    /*
+        특정 유저의 기록에서 특정 단어나 문장이 포함된 데이터 검색
+        현재는 접두를 기준으로 검색 결과 제공.
+     */
+    @Query("""
+{
+  "bool": {
+    "filter": [
+      { "term": { "user_id": "?0" } }
+    ],
+    "must": [
+      { "multi_match": {
+        "query": "?1",
+        "fields": ["native_note", "interest_note"],
+        "type": "phrase_prefix"
+      }}
+    ]
+  }
+}
+""")
+    List<UserNoteDocument> searchNotesByUserIdAndKeyword(Integer userId, String keyword);
+}

--- a/module-api/src/main/java/live/dolang/api/note/service/UserNoteService.java
+++ b/module-api/src/main/java/live/dolang/api/note/service/UserNoteService.java
@@ -1,0 +1,98 @@
+package live.dolang.api.note.service;
+
+import live.dolang.api.note.document.UserNoteDocument;
+import live.dolang.api.note.dto.UserNoteRequestDto;
+import live.dolang.api.note.repository.UserNoteSearchRepository;
+import live.dolang.core.domain.user.User;
+import live.dolang.core.domain.user.repository.UserRepository;
+import live.dolang.core.domain.user_note.UserNote;
+import live.dolang.core.domain.user_note.repository.UserNoteRepository;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.time.Instant;
+import java.util.List;
+
+@Service
+@RequiredArgsConstructor
+public class UserNoteService {
+
+    private final UserNoteRepository userNoteRepository;
+    private final UserNoteSearchRepository userNoteSearchRepository;
+    private final UserRepository userRepository;
+
+    // MySQL과 Elasticsearch에 저장
+    @Transactional
+    public boolean saveUserNote(UserNoteRequestDto requestDto) {
+
+        // try-catch로 데이터 무결성 검증
+        try {
+            // user가 데이터 상에 존재하는지 확인
+            User user = userRepository.findById(requestDto.getUserId())
+                    .orElseThrow(() -> new IllegalArgumentException("User not found with id: " + requestDto.getUserId()));
+
+            // MySQL 저장
+            UserNote userNote = UserNote.builder()
+                    .user(user)
+                    .nativeNote(requestDto.getNativeNote())
+                    .interestNote(requestDto.getInterestNote())
+                    .nativeLanguageId(requestDto.getNativeLanguageId())
+                    .interestLanguageId(requestDto.getInterestLanguageId())
+                    .createdAt(Instant.now()) // 현재 시간 저장
+                    .build();
+            userNoteRepository.save(userNote);
+
+            // Elasticsearch에 저장 (UserNoteDocument 변환)
+            UserNoteDocument userNoteDocument = UserNoteDocument.builder()
+                    .id(userNote.getId().toString())
+                    .userId(requestDto.getUserId())
+                    .nativeNote(requestDto.getNativeNote())
+                    .interestNote(requestDto.getInterestNote())
+                    .nativeLanguageId(requestDto.getNativeLanguageId())
+                    .interestLanguageId(requestDto.getInterestLanguageId())
+                    .createdAt(userNote.getCreatedAt())
+                    .build();
+            userNoteSearchRepository.save(userNoteDocument);
+            return true;
+        } catch (Exception e) {
+            return false;
+        }
+    }
+
+    // ElasticSearch, MySQL에서 ID로 조회
+    public List<UserNoteDocument> getUserNoteById(Integer userId) {
+        // 유저 정보 먼저 조회
+        User user = userRepository.findById(userId)
+                .orElseThrow(() -> new IllegalArgumentException("User not found with id: " + userId));
+
+        try {
+            // Elasticsearch에서 조회
+            return userNoteSearchRepository.findByUserId(userId);
+        } catch (Exception e) {
+            // ES 장애 시, MySQL에서 조회
+            return convertToDocumentList(userNoteRepository.findByUser(user));
+        }
+    }
+
+
+    // Elasticsearch에서 키워드 검색
+    public List<UserNoteDocument> searchUserNotes(Integer userId, String keyword) {
+        return userNoteSearchRepository.searchNotesByUserIdAndKeyword(userId, keyword);
+    }
+
+    //UserNote (MySQL 데이터) → UserNoteDocument (ES 문서) 변환
+    private List<UserNoteDocument> convertToDocumentList(List<UserNote> userNotes) {
+        return userNotes.stream().map(note ->
+                UserNoteDocument.builder()
+                        .id(note.getId().toString())
+                        .userId(note.getUser().getId())
+                        .nativeNote(note.getNativeNote())
+                        .interestNote(note.getInterestNote())
+                        .nativeLanguageId(note.getNativeLanguageId())
+                        .interestLanguageId(note.getInterestLanguageId())
+                        .createdAt(note.getCreatedAt())
+                        .build()
+        ).toList();
+    }
+}

--- a/module-api/src/main/resources/application.yml
+++ b/module-api/src/main/resources/application.yml
@@ -8,6 +8,14 @@ spring:
     url: jdbc:mysql://localhost:3306/dolang
     username: user
     password: password
+  elasticsearch:
+    uris: http://localhost:9200
+    username: elastic
+    password: password
+  data:
+    elasticsearch:
+      repositories:
+        enabled: true
   jpa:
     open-in-view: false
     properties:

--- a/module-core/src/main/java/live/dolang/core/domain/user_note/UserNote.java
+++ b/module-core/src/main/java/live/dolang/core/domain/user_note/UserNote.java
@@ -1,0 +1,46 @@
+package live.dolang.core.domain.user_note;
+
+import jakarta.persistence.*;
+import live.dolang.core.domain.user.User;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import org.hibernate.annotations.CreationTimestamp;
+
+import java.time.Instant;
+
+@Getter
+@Entity
+@Builder
+@NoArgsConstructor
+@AllArgsConstructor
+@Table(name = "user_notes", schema = "dolang")
+public class UserNote {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    @Column(name = "user_note_id")
+    private Integer id;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "user_id", foreignKey = @ForeignKey(name = "fk_user_note_user_id_to_user_id"))
+    private User user;
+
+    @Column(name = "native_note", nullable = false)
+    private String nativeNote;
+
+    @Column(name = "interest_note", nullable = false)
+    private String interestNote;
+
+    @CreationTimestamp
+    @Column(name = "created_at", updatable = false, nullable = false)
+    private Instant createdAt;
+
+    @Column(name = "native_language_id", length = 2)
+    private String nativeLanguageId;
+
+    @Column(name = "interest_language_id", length = 2)
+    private String interestLanguageId;
+
+}

--- a/module-core/src/main/java/live/dolang/core/domain/user_note/repository/UserNoteRepository.java
+++ b/module-core/src/main/java/live/dolang/core/domain/user_note/repository/UserNoteRepository.java
@@ -1,0 +1,14 @@
+package live.dolang.core.domain.user_note.repository;
+
+import live.dolang.core.domain.user.User;
+import live.dolang.core.domain.user_note.UserNote;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.querydsl.QuerydslPredicateExecutor;
+
+import java.util.List;
+
+public interface UserNoteRepository extends JpaRepository<UserNote, Integer>, QuerydslPredicateExecutor<UserNote> {
+
+    // 사용할 가능성이 적지만 ES가 날라갈 경우 사용
+    List<UserNote> findByUser(User user);
+}


### PR DESCRIPTION
### 작업사항
**기록장 기능 구현**

---

### API 및 구조 상세
**UserNoteController** (/api/note)
1. **/api/note/** 
POST 요청 시 문장or단어를 저장한다. 
(userId, nativeNote, interestNote, nativeLanguageId, interestLanguageId 필요)

2. **/api/note/{userId}** 
GET 요청 시 userId 기반으로 문장or단어들을 List에 담아 보낸다.
(id(ES 문서 id), userId, nativeNote, interestNote, nativeLanguageId, interestLanguageId, createdAt)

3. **/api/note/{userId}/search?keyword=** 
GET 요청 시 userId, keyword 기반으로 문장or단어들 중 접두가 포함된 결과들을 List에 담아 보낸다.
(id(ES 문서 id), userId, nativeNote, interestNote, nativeLanguageId, interestLanguageId, createdAt)

---
### API 호출 시, 북마크 여부 확인 로직 상세
1. try-catch와 Transactional를 통해 데이터 무결성을 보장
(MySQL부터 저장을 시도, ElasticSearch 저장 시도하는 방식으로 구현 (ES는 ACID 보장 X), User의 존재 여부 확인)

2. userId가 동일한 기록들을 반환. ES로 먼저 시도하고, 실패 시 MySQL로 시도.

3. ES에서 userId가 동일한지 먼저 확인 후 동일하다면 nativeNote, interestNote에 접두를 포함하는 단어가 있는지 확인.
(현재 한글의 경우 "안녕"을 검색하기 위해서는 "안"까지 입력해야 한다. 해당 부분은  document의 setting 수정으로 "ㅇ", "아" 만으로도 검색 가능하게 할 수 있으나 현재는 보류.)
---

추가된 implementation
|implementation|설명|
|:---|:---|
| `implementation("org.springframework.boot:spring-boot-starter-data-elasticsearch")`|spring, ES 연동을 위한 틀 제공|
